### PR TITLE
Use error_reporting() not inexistent ini_get('error_reporting') (OPS-4799)

### DIFF
--- a/src/Airbrake/EventHandler.class.php
+++ b/src/Airbrake/EventHandler.class.php
@@ -182,7 +182,7 @@ class EventHandler
         catch (InvalidHashException $e) {}
 
         // This will catch silenced @ function calls and keep them quiet.
-        if (ini_get('error_reporting') == 0) {
+        if (error_reporting() == 0) {
             return $result;
         }
 


### PR DESCRIPTION
Related PRs:

  - https://github.com/Work4Labs/php-airbrake/pull/25
  - https://github.com/Work4Labs/w4l_symfony/pull/30
  - https://github.com/Work4Labs/work4us/pull/10347